### PR TITLE
Remove confusing Notify.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ GraphQL::Errors.configure(Schema) do
   end
 
   rescue_from StandardError do |exception|
-    Notify.about(exception)
     GraphQL::ExecutionError.new("Please try to execute the query for this field later")
   end
 end


### PR DESCRIPTION
I've copy-pasted this in a couple of projects only to realize that `Notify` is not a thing too late. I think it doesn't add much to the README, but I am sure it gets copy pasted by noobs like me ;) Remove it?