### PR TITLE
CI: use 2.3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.3.4
+  - 2.3.8
 env:
   - COVERALLS_RUN_LOCALLY=true
 before_install: gem install bundler -v '< 2'


### PR DESCRIPTION
This PR updates the used Ruby to the latest version in its release series. 

(PS: 2.3 is falling out of support.)