### PR TITLE
Feature: handle rescue_from Module arguments properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ GraphQL::Errors.configure(Schema) do
     GraphQL::ExecutionError.new(exception.record.errors.full_messages.join("\n"))
   end
 
+  # uses Module to handle several similar errors with single rescue_from
+  rescue_from Handle::NetworkErrors do |_|
+    GraphQL::ExecutionError.new("Don't mind, just retry the mutation")
+  end
+
   rescue_from StandardError do |exception|
     GraphQL::ExecutionError.new("Please try to execute the query for this field later")
   end

--- a/lib/graphql/errors.rb
+++ b/lib/graphql/errors.rb
@@ -44,8 +44,11 @@ module GraphQL
       raise EmptyRescueError unless block
 
       classes.each do |klass|
-        raise NotRescuableError.new(klass.inspect) unless klass.is_a?(Class)
-        @handler_by_class[klass] ||= block
+        if klass.is_a?(Module) && klass.respond_to?(:===)
+          @handler_by_class[klass] ||= block
+        else
+          raise NotRescuableError.new(klass.inspect)
+        end
       end
     end
 
@@ -65,7 +68,7 @@ module GraphQL
 
     def find_handler(exception)
       @handler_by_class.each do |klass, handler|
-        return handler if exception.is_a?(klass)
+        return handler if klass === exception
       end
 
       nil


### PR DESCRIPTION
There is a common pattern for `rescue_from` and alike methods usage, to
pass as an argument a module which handles similar exceptions
processing. The most useful case (and the reason why I proposed that
change) is to handle different network errors with only on module.

In our project it's called Handle::NetworkErrors, it's a module which
aggregates handling of more then 20 different errors whose meaning is
just "something was wrong with the network" and in 99% of the cases it's
reasonable to handle them in exact similar way.

Unfortunately, without proposed change it's impossible to pass to
graphql-errors `rescue_from` a module. It has to be a class...
The other implementations of same method in Rails and Sidekiq accepts
Module as well as a Class.

So, my point is that would be great to have `rescue_from` behavior in a
canonical way (or you may call it, principle of least surprise).

Hope you'll find it useful and thanks for your nice gem.
